### PR TITLE
Fix not thrown exception when no initializer implemented.

### DIFF
--- a/Routable/Routable.m
+++ b/Routable/Routable.m
@@ -306,6 +306,9 @@
     if ([controller respondsToSelector:CONTROLLER_SELECTOR]) {
       controller = [controller performSelector:CONTROLLER_SELECTOR withObject:[params getControllerParams]];
     }
+    else {
+      controller = nil;
+    }
   }
 
 

--- a/RoutableTests/RoutableTests.m
+++ b/RoutableTests/RoutableTests.m
@@ -146,7 +146,7 @@
 - (void)test_noInitializers {
   [self.router map:@"routable" toController:[UIViewController class]];
   
-  STAssertThrows([self.router open:@"routable"], @"Should throw an exception when no initializers found");
+  STAssertThrows([self.router open:@"routable"], @"Should throw an exception when no initializer found");
 }
 
 @end


### PR DESCRIPTION
We recently encountered a bug because the initializers are not called as desired. After tracing Routable, I found that there are some codes designed to throw an exception when no initializers are implemented but there's a bug in that.

So I made this pull request to fix it. I also added a test case to reproduce the problem. 

Please help review, thanks! :+1: 
