### PR TITLE
Allow sharedRouter to be subclassed properly

### DIFF
--- a/Routable/Routable.m
+++ b/Routable/Routable.m
@@ -38,7 +38,7 @@
 }
 
 + (UPRouter *)newRouter {
-  return [UPRouter new];
+  return [self new];
 }
 
 @end


### PR DESCRIPTION
Using UPRouter instead of self doesn't allow subclasses to use the sharedRouter method.
