### PR TITLE
Use -[NSString pathComponents] to deal with leading and trailing slashes.

### DIFF
--- a/Routable/Routable.m
+++ b/Routable/Routable.m
@@ -253,12 +253,12 @@
     return [self.cachedRoutes objectForKey:url];
   }
   
-  NSArray *givenParts = [url componentsSeparatedByString:@"/"];
+  NSArray *givenParts = url.pathComponents;
   
   RouterParams *openParams = nil;
   for (NSString *routerUrl in self.routes.allKeys) {
     UPRouterOptions *routerOptions = (UPRouterOptions *)[self.routes objectForKey:routerUrl];
-    NSArray *routerParts = [routerUrl componentsSeparatedByString:@"/"];
+    NSArray *routerParts = routerUrl.pathComponents;
     
     if (routerParts.count != givenParts.count) {
       continue;


### PR DESCRIPTION
Noticed routable doesn't handle leading slashes in paths, so I thought this could help.

It doesn't support platforms that don't use forward slashes as path separators, but OSX and iOS do.
