### PR TITLE
add a method that can easily return params of a URL (not using a block)

### DIFF
--- a/Routable/Routable.h
+++ b/Routable/Routable.h
@@ -255,7 +255,13 @@ typedef void (^RouterOpenCallback)(NSDictionary *params);
  @exception NavigationControllerNotProvided Thrown if url opens a `UIViewController` and navigationController has not been assigned
  @exception RoutableInitializerNotFound Thrown if the mapped `UIViewController` instance does not implement -initWithRouterParams: or +allocWithRouterParams:
  */
- - (void)open:(NSString *)url animated:(BOOL)animated;
+- (void)open:(NSString *)url animated:(BOOL)animated;
+
+/**
+ Get params of a given URL, simply return the params dictionary NOT using a block
+ @param url The URL being detected (i.e. "users/16")
+ */
+- (NSDictionary*)paramsOfUrl:(NSString*)url;
 
 @end
 

--- a/Routable/Routable.m
+++ b/Routable/Routable.m
@@ -233,6 +233,11 @@
   }
 }
 
+- (NSDictionary*)paramsOfUrl:(NSString*)url{
+    RouterParams *params = [self routerParamsForUrl:url];
+    return [params getControllerParams];
+}
+
 - (void)pop {
   [self pop:YES];
 }


### PR DESCRIPTION
One can use normal method to detect/analyze URLs and to get their dictionaries.

Sometimes it's really need to return something of a function after getting the params of URL. Using blocks to do that is a little bit complex.

BTW, @clayallsopp , could you please fix your 2-spaces indentation to 4-spaces? For the reason that most developers make it 4...
