### PR TITLE
fix the performselector leak problem

### DIFF
--- a/Routable/Routable.m
+++ b/Routable/Routable.m
@@ -403,15 +403,29 @@
   SEL CONTROLLER_SELECTOR = sel_registerName("initWithRouterParams:");
   UIViewController *controller = nil;
   Class controllerClass = params.routerOptions.openClass;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    
   if ([controllerClass respondsToSelector:CONTROLLER_CLASS_SELECTOR]) {
-    controller = [controllerClass performSelector:CONTROLLER_CLASS_SELECTOR withObject:[params controllerParams]];
+      NSMethodSignature *sig  = [controllerClass methodSignatureForSelector:CONTROLLER_CLASS_SELECTOR];
+      NSInvocation *invocatin = [NSInvocation invocationWithMethodSignature:sig];
+      [invocatin setTarget:controllerClass];
+      [invocatin setSelector:CONTROLLER_CLASS_SELECTOR];
+      NSDictionary *paramsDic = [params controllerParams];
+      [invocatin setArgument:&paramsDic atIndex:2];
+      [invocatin invoke];
+      [invocatin getReturnValue: &controller];
   }
   else if ([params.routerOptions.openClass instancesRespondToSelector:CONTROLLER_SELECTOR]) {
-    controller = [[params.routerOptions.openClass alloc] performSelector:CONTROLLER_SELECTOR withObject:[params controllerParams]];
+      UIViewController *target = [controllerClass alloc];
+      NSMethodSignature *sig  = [controllerClass instanceMethodSignatureForSelector:CONTROLLER_SELECTOR];
+      NSInvocation *invocatin = [NSInvocation invocationWithMethodSignature:sig];
+      [invocatin setTarget:target];
+      [invocatin setSelector:CONTROLLER_SELECTOR];
+      NSDictionary *paramsDic = [params controllerParams];
+      [invocatin setArgument:&paramsDic atIndex:2];
+      [invocatin invoke];
+      controller = target;
   }
-#pragma clang diagnostic pop
+    
   if (!controller) {
     if (_ignoresExceptions) {
       return controller;


### PR DESCRIPTION
In - (UIViewController *)controllerForRouterParams:(RouterParams *)params method

use performselector to excute will be lead memory leak. viewController will not be excute dealloc method

so, I use nsInvocation replace the performselector.